### PR TITLE
make toolchains repo more reproducible

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -91,6 +91,7 @@ def _go_download_sdk_impl(ctx):
         )
 
         data = ctx.read("versions.json")
+        ctx.delete("versions.json")
         sdks_by_version = _parse_versions_json(data)
 
         if not version:


### PR DESCRIPTION
The versions.json file results from downloading a list of versions from go.dev. (https://go.dev/dl/?mode=json)
This API is meant to be updated for every Go release and will result in different outputs when rerun in the future.

By deleting the file, we make the behavior more reproducible: As long as a specific version is requested, this should result in reproducible behavior. (This assumes that go.dev does not replace released SDK artifacts, which should be a fair assumption).

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
